### PR TITLE
Print any errors returned by RTM

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -94,12 +94,12 @@ LOOP:
 					match.Handler(ctx)
 				}
 
-			case *slack.RTMError:
-				fmt.Printf("Error: %s\n", ev.Error())
-
 			case *slack.InvalidAuthEvent:
 				fmt.Printf("Invalid credentials\n")
 				break LOOP
+
+			case error:
+				fmt.Printf("Error %T: %s\n", ev, ev.Error())
 
 			default:
 				// Ignore other events..


### PR DESCRIPTION
Print out any and all error events returned by the RTM for auditing purposes.